### PR TITLE
Add folder support for pages

### DIFF
--- a/apiserver/plane/app/serializers/page.py
+++ b/apiserver/plane/app/serializers/page.py
@@ -35,6 +35,7 @@ class PageSerializer(BaseSerializer):
             "color",
             "labels",
             "parent",
+            "is_folder",
             "is_favorite",
             "is_locked",
             "archived_at",

--- a/apiserver/plane/app/views/page/base.py
+++ b/apiserver/plane/app/views/page/base.py
@@ -71,7 +71,8 @@ class PageViewSet(BaseViewSet):
             entity_identifier=OuterRef("pk"),
             workspace__slug=self.kwargs.get("slug"),
         )
-        return self.filter_queryset(
+        parent_id = self.request.GET.get("parent")
+        queryset = (
             super()
             .get_queryset()
             .filter(workspace__slug=self.kwargs.get("slug"))
@@ -80,7 +81,13 @@ class PageViewSet(BaseViewSet):
                 projects__project_projectmember__is_active=True,
                 projects__archived_at__isnull=True,
             )
-            .filter(parent__isnull=True)
+        )
+        if parent_id:
+            queryset = queryset.filter(parent_id=parent_id)
+        else:
+            queryset = queryset.filter(parent__isnull=True)
+        return self.filter_queryset(
+            queryset
             .filter(Q(owned_by=self.request.user) | Q(access=0))
             .prefetch_related("projects")
             .select_related("workspace")

--- a/apiserver/plane/db/migrations/0105_page_is_folder.py
+++ b/apiserver/plane/db/migrations/0105_page_is_folder.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('db', '0104_merge_20250607_2213'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='page',
+            name='is_folder',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/apiserver/plane/db/models/page.py
+++ b/apiserver/plane/db/models/page.py
@@ -47,6 +47,7 @@ class Page(BaseModel):
         blank=True,
         related_name="child_page",
     )
+    is_folder = models.BooleanField(default=False)
     archived_at = models.DateField(null=True)
     is_locked = models.BooleanField(default=False)
     view_props = models.JSONField(default=get_view_props)

--- a/packages/types/src/pages.d.ts
+++ b/packages/types/src/pages.d.ts
@@ -13,6 +13,8 @@ export type TPage = {
   id: string | undefined;
   is_favorite: boolean;
   is_locked: boolean;
+  is_folder: boolean;
+  parent?: string | null | undefined;
   label_ids: string[] | undefined;
   name: string | undefined;
   owned_by: string | undefined;

--- a/web/core/services/page/project-page.service.ts
+++ b/web/core/services/page/project-page.service.ts
@@ -15,8 +15,15 @@ export class ProjectPageService extends APIService {
     this.fileUploadService = new FileUploadService();
   }
 
-  async fetchAll(workspaceSlug: string, projectId: string): Promise<TPage[]> {
-    return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/pages/`)
+  async fetchAll(
+    workspaceSlug: string,
+    projectId: string,
+    parent?: string
+  ): Promise<TPage[]> {
+    const query = parent ? `?parent=${parent}` : "";
+    return this.get(
+      `/api/workspaces/${workspaceSlug}/projects/${projectId}/pages/${query}`
+    )
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data;

--- a/web/core/store/pages/base-page.ts
+++ b/web/core/store/pages/base-page.ts
@@ -87,6 +87,8 @@ export class BasePage implements TBasePage {
   anchor?: string | null | undefined;
   is_favorite: boolean;
   is_locked: boolean;
+  is_folder: boolean;
+  parent: string | null | undefined;
   archived_at: string | null | undefined;
   workspace: string | undefined;
   project_ids?: string[] | undefined;
@@ -120,6 +122,8 @@ export class BasePage implements TBasePage {
     this.anchor = page?.anchor || undefined;
     this.is_favorite = page?.is_favorite || false;
     this.is_locked = page?.is_locked || false;
+    this.is_folder = page?.is_folder || false;
+    this.parent = page?.parent || undefined;
     this.archived_at = page?.archived_at || undefined;
     this.workspace = page?.workspace || undefined;
     this.project_ids = page?.project_ids || undefined;
@@ -147,6 +151,8 @@ export class BasePage implements TBasePage {
       anchor: observable.ref,
       is_favorite: observable.ref,
       is_locked: observable.ref,
+      is_folder: observable.ref,
+      parent: observable.ref,
       archived_at: observable.ref,
       workspace: observable.ref,
       project_ids: observable,
@@ -223,6 +229,8 @@ export class BasePage implements TBasePage {
       logo_props: this.logo_props,
       is_favorite: this.is_favorite,
       is_locked: this.is_locked,
+      is_folder: this.is_folder,
+      parent: this.parent,
       archived_at: this.archived_at,
       workspace: this.workspace,
       project_ids: this.project_ids,

--- a/web/core/store/pages/project-page.store.ts
+++ b/web/core/store/pages/project-page.store.ts
@@ -47,7 +47,8 @@ export interface IProjectPageStore {
   fetchPagesList: (
     workspaceSlug: string,
     projectId: string,
-    pageType?: TPageNavigationTabs
+    pageType?: TPageNavigationTabs,
+    parent?: string
   ) => Promise<TPage[] | undefined>;
   fetchPageDetails: (workspaceSlug: string, projectId: string, pageId: string) => Promise<TPage | undefined>;
   createPage: (pageData: Partial<TPage>) => Promise<TPage | undefined>;
@@ -194,7 +195,12 @@ export class ProjectPageStore implements IProjectPageStore {
   /**
    * @description fetch all the pages
    */
-  fetchPagesList = async (workspaceSlug: string, projectId: string, pageType?: TPageNavigationTabs) => {
+  fetchPagesList = async (
+    workspaceSlug: string,
+    projectId: string,
+    pageType?: TPageNavigationTabs,
+    parent?: string
+  ) => {
     try {
       if (!workspaceSlug || !projectId) return undefined;
 
@@ -204,7 +210,7 @@ export class ProjectPageStore implements IProjectPageStore {
         this.error = undefined;
       });
 
-      const pages = await this.service.fetchAll(workspaceSlug, projectId);
+      const pages = await this.service.fetchAll(workspaceSlug, projectId, parent);
       runInAction(() => {
         for (const page of pages) {
           if (page?.id) {


### PR DESCRIPTION
## Summary
- add `is_folder` field to Page model and migrate
- expose `is_folder` in Page serializer
- allow filtering pages by parent in PageViewSet
- include parent and folder data on pages in UI types
- update page services and stores to pass parent folder ID
- keep front-end page model in sync with backend

## Testing
- `python run_tests.py -u` *(fails: ImportError celery)*
- `python -m pytest plane/tests/unit/` *(fails: ModuleNotFoundError: celery)*
- `yarn lint` *(fails: network access error)*

------
https://chatgpt.com/codex/tasks/task_e_684584593648832d89293b69c5b810d1