### PR TITLE
Add folder move options for pages

### DIFF
--- a/apiserver/plane/app/serializers/page.py
+++ b/apiserver/plane/app/serializers/page.py
@@ -35,6 +35,7 @@ class PageSerializer(BaseSerializer):
             "color",
             "labels",
             "parent",
+            "is_folder",
             "is_favorite",
             "is_locked",
             "archived_at",

--- a/apiserver/plane/app/views/page/base.py
+++ b/apiserver/plane/app/views/page/base.py
@@ -71,7 +71,8 @@ class PageViewSet(BaseViewSet):
             entity_identifier=OuterRef("pk"),
             workspace__slug=self.kwargs.get("slug"),
         )
-        return self.filter_queryset(
+        parent_id = self.request.GET.get("parent")
+        queryset = (
             super()
             .get_queryset()
             .filter(workspace__slug=self.kwargs.get("slug"))
@@ -80,7 +81,13 @@ class PageViewSet(BaseViewSet):
                 projects__project_projectmember__is_active=True,
                 projects__archived_at__isnull=True,
             )
-            .filter(parent__isnull=True)
+        )
+        if parent_id:
+            queryset = queryset.filter(parent_id=parent_id)
+        else:
+            queryset = queryset.filter(parent__isnull=True)
+        return self.filter_queryset(
+            queryset
             .filter(Q(owned_by=self.request.user) | Q(access=0))
             .prefetch_related("projects")
             .select_related("workspace")

--- a/apiserver/plane/db/migrations/0105_page_is_folder.py
+++ b/apiserver/plane/db/migrations/0105_page_is_folder.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('db', '0104_merge_20250607_2213'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='page',
+            name='is_folder',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/apiserver/plane/db/models/page.py
+++ b/apiserver/plane/db/models/page.py
@@ -47,6 +47,7 @@ class Page(BaseModel):
         blank=True,
         related_name="child_page",
     )
+    is_folder = models.BooleanField(default=False)
     archived_at = models.DateField(null=True)
     is_locked = models.BooleanField(default=False)
     view_props = models.JSONField(default=get_view_props)

--- a/packages/types/src/pages.d.ts
+++ b/packages/types/src/pages.d.ts
@@ -13,6 +13,8 @@ export type TPage = {
   id: string | undefined;
   is_favorite: boolean;
   is_locked: boolean;
+  is_folder: boolean;
+  parent?: string | null | undefined;
   label_ids: string[] | undefined;
   name: string | undefined;
   owned_by: string | undefined;

--- a/web/ce/components/pages/header/move-control.tsx
+++ b/web/ce/components/pages/header/move-control.tsx
@@ -1,10 +1,38 @@
 "use client";
 
 // store
+import { useState } from "react";
+import { FileOutput } from "lucide-react";
+import { Tooltip } from "@plane/ui";
+import { MovePageModal } from "@/plane-web/components/pages";
 import { TPageInstance } from "@/store/pages/base-page";
 
 export type TPageMoveControlProps = {
   page: TPageInstance;
 };
 
-export const PageMoveControl = ({}: TPageMoveControlProps) => null;
+export const PageMoveControl: React.FC<TPageMoveControlProps> = ({ page }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (!page) return null;
+
+  return (
+    <>
+      <MovePageModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        page={page}
+      />
+      <Tooltip tooltipContent="Move" position="bottom">
+        <button
+          type="button"
+          className="flex-shrink-0 size-6 grid place-items-center rounded text-custom-text-200 hover:text-custom-text-100 hover:bg-custom-background-80"
+          onClick={() => setIsOpen(true)}
+          aria-label="Move"
+        >
+          <FileOutput className="size-3.5" />
+        </button>
+      </Tooltip>
+    </>
+  );
+};

--- a/web/ce/components/pages/modals/move-page-modal.tsx
+++ b/web/ce/components/pages/modals/move-page-modal.tsx
@@ -1,4 +1,11 @@
 // store types
+import { useState } from "react";
+import { observer } from "mobx-react";
+import { Button, CustomSearchSelect, ModalCore } from "@plane/ui";
+import type { ICustomSearchSelectOption } from "@plane/types";
+// hooks
+import { EPageStoreType, usePageStore } from "@/plane-web/hooks/store";
+// store types
 import { TPageInstance } from "@/store/pages/base-page";
 
 export type TMovePageModalProps = {
@@ -7,4 +14,51 @@ export type TMovePageModalProps = {
   page: TPageInstance;
 };
 
-export const MovePageModal: React.FC<TMovePageModalProps> = () => null;
+export const MovePageModal: React.FC<TMovePageModalProps> = observer((props) => {
+  const { isOpen, onClose, page } = props;
+  const { getFolderPages } = usePageStore(EPageStoreType.PROJECT);
+  const [selectedParent, setSelectedParent] = useState<string | null>(page.parent ?? null);
+
+  if (!page) return null;
+
+  const folderOptions: ICustomSearchSelectOption[] = getFolderPages()
+    .filter((f) => f.id !== page.id)
+    .map((folder) => ({
+      value: folder.id,
+      query: folder.name || "",
+      content: folder.name || "Untitled",
+    }));
+  folderOptions.unshift({ value: null, query: "root", content: "Root" });
+
+  const handleMove = async () => {
+    await page.moveToFolder(selectedParent);
+    onClose();
+  };
+
+  return (
+    <ModalCore isOpen={isOpen} handleClose={onClose}>
+      <div className="space-y-5 p-5">
+        <h3 className="text-xl font-medium text-custom-text-200">Move Page</h3>
+        <CustomSearchSelect
+          value={selectedParent}
+          onChange={(val: string | null) => setSelectedParent(val)}
+          options={folderOptions}
+          label={
+            folderOptions.find((o) => o.value === selectedParent)?.content ||
+            "Root"
+          }
+          optionsClassName="max-w-48"
+          placement="bottom-end"
+        />
+      </div>
+      <div className="px-5 py-4 flex items-center justify-end gap-2 border-t-[0.5px] border-custom-border-200">
+        <Button variant="neutral-primary" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button variant="primary" size="sm" onClick={handleMove}>
+          Move
+        </Button>
+      </div>
+    </ModalCore>
+  );
+});

--- a/web/core/components/pages/modals/create-page-modal.tsx
+++ b/web/core/components/pages/modals/create-page-modal.tsx
@@ -37,6 +37,7 @@ export const CreatePageModal: FC<Props> = (props) => {
     id: undefined,
     name: "",
     logo_props: undefined,
+    parent: null,
   });
   // router
   const router = useAppRouter();
@@ -52,7 +53,7 @@ export const CreatePageModal: FC<Props> = (props) => {
   }, [pageAccess]);
 
   const handleStateClear = () => {
-    setPageFormData({ id: undefined, name: "", access: pageAccess });
+    setPageFormData({ id: undefined, name: "", access: pageAccess, parent: null });
     handleModalClose();
   };
 

--- a/web/core/components/pages/modals/page-form.tsx
+++ b/web/core/components/pages/modals/page-form.tsx
@@ -9,7 +9,14 @@ import { ETabIndices, EPageAccess } from "@plane/constants";
 import { useTranslation } from "@plane/i18n";
 import { TPage } from "@plane/types";
 // ui
-import { Button, EmojiIconPicker, EmojiIconPickerTypes, Input } from "@plane/ui";
+import {
+  Button,
+  EmojiIconPicker,
+  EmojiIconPickerTypes,
+  Input,
+  CustomSearchSelect,
+} from "@plane/ui";
+import type { ICustomSearchSelectOption } from "@plane/types";
 import { Logo } from "@/components/common";
 // constants
 import { AccessField } from "@/components/common/access-field";
@@ -18,6 +25,8 @@ import { convertHexEmojiToDecimal } from "@/helpers/emoji.helper";
 import { getTabIndex } from "@/helpers/tab-indices.helper";
 // hooks
 import { usePlatformOS } from "@/hooks/use-platform-os";
+// plane web hooks
+import { EPageStoreType, usePageStore } from "@/plane-web/hooks/store";
 
 type Props = {
   formData: Partial<TPage>;
@@ -40,6 +49,7 @@ export const PageForm: React.FC<Props> = (props) => {
   // hooks
   const { isMobile } = usePlatformOS();
   const { t } = useTranslation();
+  const { getFolderPages } = usePageStore(EPageStoreType.PROJECT);
   // state
   const [isOpen, setIsOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -110,11 +120,11 @@ export const PageForm: React.FC<Props> = (props) => {
             }
           />
           <div className="space-y-1 flew-grow w-full">
-            <Input
-              id="name"
-              type="text"
-              value={formData.name}
-              onChange={(e) => handleFormData("name", e.target.value)}
+          <Input
+            id="name"
+            type="text"
+            value={formData.name}
+            onChange={(e) => handleFormData("name", e.target.value)}
               placeholder="Title"
               className="w-full resize-none text-base"
               tabIndex={getIndex("name")}
@@ -125,6 +135,29 @@ export const PageForm: React.FC<Props> = (props) => {
               <span className="text-xs text-red-500">Max length of the name should be less than 255 characters</span>
             )}
           </div>
+        </div>
+        {/* folder selection */}
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-custom-text-200">Folder</span>
+          <CustomSearchSelect
+            value={formData.parent ?? null}
+            onChange={(val: string | null) => handleFormData("parent", val)}
+            options={
+              [{ value: null, query: "root", content: "Root" },
+              ...getFolderPages()
+                ?.map((folder) => ({
+                  value: folder.id,
+                  query: folder.name || "",
+                  content: folder.name || "Untitled",
+                }))] as ICustomSearchSelectOption[]
+            }
+            label={
+              getFolderPages()
+                ?.find((f) => f.id === formData.parent)?.name || "Root"
+            }
+            optionsClassName="max-w-48"
+            placement="bottom-end"
+          />
         </div>
       </div>
       <div className="px-5 py-4 flex items-center justify-between gap-2 border-t-[0.5px] border-custom-border-200">

--- a/web/core/services/page/project-page.service.ts
+++ b/web/core/services/page/project-page.service.ts
@@ -15,8 +15,15 @@ export class ProjectPageService extends APIService {
     this.fileUploadService = new FileUploadService();
   }
 
-  async fetchAll(workspaceSlug: string, projectId: string): Promise<TPage[]> {
-    return this.get(`/api/workspaces/${workspaceSlug}/projects/${projectId}/pages/`)
+  async fetchAll(
+    workspaceSlug: string,
+    projectId: string,
+    parent?: string
+  ): Promise<TPage[]> {
+    const query = parent ? `?parent=${parent}` : "";
+    return this.get(
+      `/api/workspaces/${workspaceSlug}/projects/${projectId}/pages/${query}`
+    )
       .then((response) => response?.data)
       .catch((error) => {
         throw error?.response?.data;

--- a/web/core/store/pages/base-page.ts
+++ b/web/core/store/pages/base-page.ts
@@ -87,6 +87,8 @@ export class BasePage implements TBasePage {
   anchor?: string | null | undefined;
   is_favorite: boolean;
   is_locked: boolean;
+  is_folder: boolean;
+  parent: string | null | undefined;
   archived_at: string | null | undefined;
   workspace: string | undefined;
   project_ids?: string[] | undefined;
@@ -120,6 +122,8 @@ export class BasePage implements TBasePage {
     this.anchor = page?.anchor || undefined;
     this.is_favorite = page?.is_favorite || false;
     this.is_locked = page?.is_locked || false;
+    this.is_folder = page?.is_folder || false;
+    this.parent = page?.parent || undefined;
     this.archived_at = page?.archived_at || undefined;
     this.workspace = page?.workspace || undefined;
     this.project_ids = page?.project_ids || undefined;
@@ -147,6 +151,8 @@ export class BasePage implements TBasePage {
       anchor: observable.ref,
       is_favorite: observable.ref,
       is_locked: observable.ref,
+      is_folder: observable.ref,
+      parent: observable.ref,
       archived_at: observable.ref,
       workspace: observable.ref,
       project_ids: observable,
@@ -223,6 +229,8 @@ export class BasePage implements TBasePage {
       logo_props: this.logo_props,
       is_favorite: this.is_favorite,
       is_locked: this.is_locked,
+      is_folder: this.is_folder,
+      parent: this.parent,
       archived_at: this.archived_at,
       workspace: this.workspace,
       project_ids: this.project_ids,
@@ -573,6 +581,25 @@ export class BasePage implements TBasePage {
    * @description duplicate the page
    */
   duplicate = async () => await this.services.duplicate();
+
+  /**
+   * @description 페이지를 다른 폴더로 이동
+   */
+  moveToFolder = async (parentId: string | null) => {
+    if (!this.id) return;
+    const originalParent = this.parent;
+    runInAction(() => {
+      this.parent = parentId;
+    });
+    try {
+      await this.services.update({ parent: parentId });
+    } catch (error) {
+      runInAction(() => {
+        this.parent = originalParent;
+      });
+      throw error;
+    }
+  };
 
   /**
    * @description mutate multiple properties at once

--- a/web/core/store/pages/project-page.store.ts
+++ b/web/core/store/pages/project-page.store.ts
@@ -47,7 +47,8 @@ export interface IProjectPageStore {
   fetchPagesList: (
     workspaceSlug: string,
     projectId: string,
-    pageType?: TPageNavigationTabs
+    pageType?: TPageNavigationTabs,
+    parent?: string
   ) => Promise<TPage[] | undefined>;
   fetchPageDetails: (workspaceSlug: string, projectId: string, pageId: string) => Promise<TPage | undefined>;
   createPage: (pageData: Partial<TPage>) => Promise<TPage | undefined>;
@@ -177,6 +178,17 @@ export class ProjectPageStore implements IProjectPageStore {
    */
   getPageById = computedFn((pageId: string) => this.data?.[pageId] || undefined);
 
+  /**
+   * @description 현재 프로젝트의 모든 폴더 페이지 반환
+   */
+  getFolderPages = computedFn(() => {
+    const { projectId } = this.store.router;
+    if (!projectId) return [] as TProjectPage[];
+    return Object.values(this.data || {}).filter(
+      (p) => p.project_ids?.includes(projectId) && p.is_folder
+    );
+  });
+
   updateFilters = <T extends keyof TPageFilters>(filterKey: T, filterValue: TPageFilters[T]) => {
     runInAction(() => {
       set(this.filters, [filterKey], filterValue);
@@ -194,7 +206,12 @@ export class ProjectPageStore implements IProjectPageStore {
   /**
    * @description fetch all the pages
    */
-  fetchPagesList = async (workspaceSlug: string, projectId: string, pageType?: TPageNavigationTabs) => {
+  fetchPagesList = async (
+    workspaceSlug: string,
+    projectId: string,
+    pageType?: TPageNavigationTabs,
+    parent?: string
+  ) => {
     try {
       if (!workspaceSlug || !projectId) return undefined;
 
@@ -204,7 +221,7 @@ export class ProjectPageStore implements IProjectPageStore {
         this.error = undefined;
       });
 
-      const pages = await this.service.fetchAll(workspaceSlug, projectId);
+      const pages = await this.service.fetchAll(workspaceSlug, projectId, parent);
       runInAction(() => {
         for (const page of pages) {
           if (page?.id) {


### PR DESCRIPTION
## Summary
- allow selecting parent folder when creating pages
- implement page moving via new modal and control
- expose folder pages from project page store
- add `moveToFolder` helper on `BasePage`

## Testing
- `python run_tests.py -u` *(fails: file not found)*
- `python -m pytest plane/tests/unit/` *(fails: file or directory not found)*
- `yarn lint` *(fails: network access error)*

------
https://chatgpt.com/codex/tasks/task_e_684584593648832d89293b69c5b810d1